### PR TITLE
fix: closest apc color function

### DIFF
--- a/device_apcminimkii.py
+++ b/device_apcminimkii.py
@@ -344,12 +344,7 @@ APC_COLORS = (
 
 def closestApcColor(rgb):
     r, g, b = rgb
-    color_diffs = []
-    for color in APC_COLORS:
-        index, cr, cg, cb = color
-        color_diff = math.sqrt((r - cr)**2 + (g - cg)**2 + (b - cb)**2)
-        color_diffs.append((color_diff, color))
-    return min(color_diffs)[1]
+    return min(APC_COLORS, key=lambda c: abs(r - c[1]) + abs(g - c[2]) + abs(b - c[3]))
 
 
 def flColorHexToNearestApcIndex(colorHex):


### PR DESCRIPTION
This is the way of the snake, my young padawan.
It performs 50% faster.

Is it necessary to use the normed distance of 2 colors? If not, it is overly complex to use square root and power.

Your usage of the min function also worked, because when you use min on a list of tuples, it compares all the first values and if there are two equally small, then the second values etc. So because you had color_diff first and then color in the tuple it worked (otherwise it would not have).